### PR TITLE
Add version req to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Installation
+TODO
+
+## Supported versions
+To build and rus this package you will need to use python >=3.6
+
 ## How to build
 To build this python package you will need to have python build installed as a package. To do this please run `python -m pip install build`. To build ImageBuilderAPI navigate to root directory of this repo and run `python -m build`. When build finfishes new directory will appear name `dist`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     pynacl
+    requests
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This PR adds a requirement for python into readme file. This package has been tested for python 3.4 and 3.5 however, 3.4 does not work at all as one of the dependency PyNacl which is used for encryption only supports python >=3.5, and 3.5 does not support python `build package`. Therefore it was decided to use python 3.6 as minimal version.

Close #5 